### PR TITLE
Icons for active ban and active mute showing on player profile without active ban or mute.

### DIFF
--- a/application/app/PlayerBan.php
+++ b/application/app/PlayerBan.php
@@ -9,7 +9,10 @@ class PlayerBan extends RecordBaseModel {
 
 	public function scopeActive($query)
 	{
-		return $query->where('expires', '>=', Carbon::now()->timestamp)->orWhere('expires', '=', 0);
+		return $query->where(function ($query) {
+			$query->where('expires', '>=', Carbon::now()->timestamp)
+			->orWhere('expires', '=', 0);
+		});
 	}
 
 	public function scopeOutdated($query)

--- a/application/app/PlayerMute.php
+++ b/application/app/PlayerMute.php
@@ -9,7 +9,10 @@ class PlayerMute extends RecordBaseModel {
 
 	public function scopeActive($query)
 	{
-		return $query->where('expires', '>=', Carbon::now()->timestamp)->orWhere('expires', '=', 0);
+		return $query->where(function ($query) {
+		    $query->where('expires', '>=', Carbon::now()->timestamp)
+			->orWhere('expires', '=', 0);
+		});
 	}
 
 	public function scopeOutdated($query)


### PR DESCRIPTION
When chained, the active() scope on bans and mutes was being joined with an or, so any ban or mute with an expiry of 0 was being included even if it does not apply to the currently viewed player. Fixes #30 