### PR TITLE
Support hyphens in player URLs

### DIFF
--- a/application/app/Helpers/UuidConverter.php
+++ b/application/app/Helpers/UuidConverter.php
@@ -5,5 +5,7 @@ function id_to_uuid($id) {
 }
 
 function uuid_to_id($uuid) {
+	// Strip out hyphens for better compatability with banmanager
+	$uuid = str_replace("-","", $uuid);
 	return pack("H*", $uuid);
 }


### PR DESCRIPTION
This will fix #68 by stripping out any hyphens passed in the player URL before searching for the player by UUID